### PR TITLE
Fixed Navigation Links

### DIFF
--- a/WiCS/wicsWebsite/templates/headerFooter.html
+++ b/WiCS/wicsWebsite/templates/headerFooter.html
@@ -25,14 +25,14 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a class="navbar-brand" href="#welcome">WiCS</a>
+            <a class="navbar-brand" href="{% url 'home' %}#welcome">WiCS</a>
         </div>
 
         <div class="collapse navbar-collapse" id="navbar-collapse-header">
             <ul class="nav navbar-nav navbar-left">
-                <li><a href="#about">About Us</a></li>
-                <li><a href="#meetings">Meetings</a></li>
-                <li><a href="#sponsors">Sponsors</a></li>
+                <li><a href="{% url 'home' %}#about">About Us</a></li>
+                <li><a href="{% url 'home' %}#meetings">Meetings</a></li>
+                <li><a href="{% url 'home' %}#sponsors">Sponsors</a></li>
             </ul>
 
             <ul class="nav navbar-nav navbar-right">


### PR DESCRIPTION
Navigation links were broken whenever we were on any page other than
the home page. Fixed them so that they worked across the website.

NOTE: In order to properly test it, we'll probably need to merge in the Events page or some other page so that we can see functionality of the nav bar outside of the home page.